### PR TITLE
Modify gemspec

### DIFF
--- a/fcoin_ruby_client.gemspec
+++ b/fcoin_ruby_client.gemspec
@@ -11,15 +11,6 @@ Gem::Specification.new do |spec|
   spec.summary       = %q{A Ruby wrapper for Fcoin API}
   spec.description   = %q{A Ruby wrapper for Fcoin API}
 
-  # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
-  # to allow pushing to a single host or delete this section to allow pushing to any host.
-  if spec.respond_to?(:metadata)
-    spec.metadata["allowed_push_host"] = "TODO: Set to 'http://mygemserver.com'"
-  else
-    raise "RubyGems 2.0 or newer is required to protect against " \
-      "public gem pushes."
-  end
-
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end


### PR DESCRIPTION
### Summary
Workaround:

```
$ be rake release
fcoin_ruby_client 0.1.0 built to pkg/fcoin_ruby_client-0.1.0.gem.
Tagged v0.1.0.
Pushed git commits and tags.
rake aborted!
ERROR:  While executing gem ... (Gem::CommandLineError)
    Too many gem names (/Users/fukudayukihiro/RubymineProjects/fcoin_ruby_client/pkg/fcoin_ruby_client-0.1.0.gem, Set, to, http://mygemserver.com); please specify only one
/Users/fukudayukihiro/.rbenv/versions/2.4.1/bin/bundle:22:in `load'
/Users/fukudayukihiro/.rbenv/versions/2.4.1/bin/bundle:22:in `<main>'
Tasks: TOP => release => release:rubygem_push
(See full trace by running task with --trace)
```
